### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 5GMS-Aware Applications
 
-This repository holds applications that can be used to test and demo other 5G-MAG Reference Tools related to 5GMS.
+This repository holds applications that can be used to test and demonstrate other 5G-MAG Reference Tools related to 5GMS.
 
 ## Current Applications and Folders
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# 5G-MAG Reference Tools: 5G Media Streaming Aware Applications
+# 5GMSd-Aware Applications
 
-This repository holds applications that can be used to test and demo other 5G-MAG Reference Tools.
+This repository holds applications that can be used to test and demo other 5G-MAG Reference Tools related to 5GMSd.
 
 ## Current Applications and Folders
 
 Each folder within the repository contains a different application with its own code, documentation and license file.
 This is a list of the current applications available:
-* [5GMSd Aware Application](https://github.com/5G-MAG/rt-5gms-application/tree/development/fivegmag_5GMSdAwareApplication) (5G-MAG Public License v1.0): The 5GMSd Aware Application is an Android application that serves as a reference implementation for 5GMS downlink media streaming. It uses the Media Stream Handler for playback and communication with the Media Session Handler.
+* [5GMSd-Aware Application](https://github.com/5G-MAG/rt-5gms-application/tree/development/fivegmag_5GMSdAwareApplication) (5G-MAG Public License v1.0): The 5GMSd Aware Application is an Android application that serves as a reference implementation for 5GMS downlink media streaming. It uses the Media Stream Handler for playback and communication with the Media Session Handler.
 * [Exo DVB-I Player](https://github.com/5G-MAG/rt-5gms-application/tree/development/fivegmag_ExoDvbi_player) (5G-MAG Public License v1.0): This project uses the Android ExoPlayer and the DVB-I Reference Client functionality to provide the capabilities to select and play back media content.
 * [Sample 5G-MAG Player](https://github.com/5G-MAG/rt-5gms-application/tree/main/fivegmag_sampleplayer) (5G-MAG Public License v1.0): an application for initial testing purposes which integrates an instance of Exoplayer and a hard-coded URL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 5GMSd-Aware Applications
+# 5GMS-Aware Applications
 
-This repository holds applications that can be used to test and demo other 5G-MAG Reference Tools related to 5GMSd.
+This repository holds applications that can be used to test and demo other 5G-MAG Reference Tools related to 5GMS.
 
 ## Current Applications and Folders
 

--- a/fivegmag_5GMSdAwareApplication/Readme.md
+++ b/fivegmag_5GMSdAwareApplication/Readme.md
@@ -1,18 +1,33 @@
-# 5G-MAG Reference Tools: 5GMSd-Aware Application
+# 5GMSd-Aware Application
 
 This repository holds the 5GMSd-Aware Application implementation of the 5G-MAG Reference Tools.
 
 ## Introduction
 
+The 5GMSd-Aware Application is an application in the UE, provided by the 5GMSd Application Provider,
+that contains the service logic of the 5GMSd application service, and interacts with other 5GMSd
+Client and Network functions via the interfaces and APIs defined in the 5GMSd architecture.
+The 5GMSd-Aware Application controls the Media Session Handler via a UE-internal API defined at reference point M6d. This reference point could, for example, be realized as a JavaScript API in a web browser or via Inter Process Communication (IPC) for native Android applications. The 5GMSd-Aware Application controls the Media Player via a UE-internal API defined at reference point M7.
+
+### About the implementation
+
 The 5GMSd-Aware Application is an Android application that serves as a reference implementation for
-5GMS downlink media streaming. It uses
+5G Downlink Media Streaming. It uses
 the [Media Stream Handler](https://github.com/5G-MAG/rt-5gms-media-stream-handle) for playback and
 communication with
 the [Media Session Handler](https://github.com/5G-MAG/rt-5gms-media-session-handler).
 
-The 5GMSd-Aware Application is an application in the UE, provided by the 5GMS Application Provider,
-that contains the service logic of the 5GMS application, and interacts with other 5GMS
-client and network functions via the interfaces and APIs defined in the 5GMS architecture.
+### Specifications
+
+A list of specification related to this repository is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
+
+
+
+
+
+
+
+
 
 ## Downloading
 


### PR DESCRIPTION
Rationale of the update:

Keep the name of the repo generic (5GMS)
Keep 5GMSd-Aware Application as one of the apps