### PR TITLE
Visualization of selected bitrate and Representation 

### DIFF
--- a/fivegmag_5GMSdAwareApplication/app/build.gradle
+++ b/fivegmag_5GMSdAwareApplication/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
+    implementation 'org.greenrobot:eventbus:3.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.fivegmag:a5gmscommonlibrary:1.0.2'
     implementation 'com.fivegmag:a5gmsmediastreamhandler:1.0.2'

--- a/fivegmag_5GMSdAwareApplication/app/src/main/assets/config.properties.xml
+++ b/fivegmag_5GMSdAwareApplication/app/src/main/assets/config.properties.xml
@@ -5,4 +5,6 @@
     <!--<entry key="m8LocalAfAndAs">m8/config_local_af.json</entry>-->
     <entry key="m85GMAGHost">https://rt.5g-mag.com/</entry>
     <!-- <entry key="m8LocalDummyHost">http://10.147.67.179:3003/m8/</entry>-->
+    <entry key="m8LocalDummyHost">http://192.168.178.78:3003/m8/</entry>
+    <!-- <entry key="m8LocalDummyHost">http://194.95.175.90:3003/m8/</entry> -->
 </properties>

--- a/fivegmag_5GMSdAwareApplication/app/src/main/java/com/fivegmag/a5gmsdawareapplication/MediaStreamHandlerEventHandler.kt
+++ b/fivegmag_5GMSdAwareApplication/app/src/main/java/com/fivegmag/a5gmsdawareapplication/MediaStreamHandlerEventHandler.kt
@@ -1,0 +1,41 @@
+package com.fivegmag.a5gmsdawareapplication
+
+import android.content.Context
+import android.widget.TextView
+import androidx.media3.common.util.UnstableApi
+import com.fivegmag.a5gmscommonlibrary.eventbus.DownstreamFormatChangedEvent
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+
+@UnstableApi
+/**
+ * This class handles messages that are dispatched by the Media Stream Handler.
+ * Implements a pub/sub pattern using the eventbus library.
+ *
+ */
+class MediaStreamHandlerEventHandler {
+
+    private lateinit var representationInfoTextView: TextView
+    private lateinit var context: Context
+
+    fun initialize(repInfoTextView: TextView, ctxt: Context) {
+        representationInfoTextView = repInfoTextView
+        context = ctxt
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onDownstreamFormatChangedEvent(event: DownstreamFormatChangedEvent) {
+        // Handle the event
+        if (event.mediaLoadData.trackFormat?.containerMimeType?.contains(
+                "video",
+                ignoreCase = true
+            ) == true
+        ) {
+            val kbitsPerSecond =
+                event.mediaLoadData.trackFormat?.peakBitrate?.div(1000).toString()
+            val id = event.mediaLoadData.trackFormat?.id.toString()
+            val text = context.getString(R.string.representationInfo, kbitsPerSecond, id)
+            representationInfoTextView.text = text
+        }
+    }
+}

--- a/fivegmag_5GMSdAwareApplication/app/src/main/res/layout-land/activity_main.xml
+++ b/fivegmag_5GMSdAwareApplication/app/src/main/res/layout-land/activity_main.xml
@@ -85,5 +85,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/idStreamSpinner" />
 
+    <TextView
+        android:id="@+id/representationInfo"
+        android:layout_width="348dp"
+        android:layout_height="19dp"
+        android:text=""
+        android:textColor="#FFFFFF"
+        app:layout_constraintStart_toStartOf="@+id/idExoPlayerVIew"
+        app:layout_constraintTop_toTopOf="@+id/idExoPlayerVIew" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/fivegmag_5GMSdAwareApplication/app/src/main/res/layout/activity_main.xml
+++ b/fivegmag_5GMSdAwareApplication/app/src/main/res/layout/activity_main.xml
@@ -86,5 +86,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/idStreamSpinner" />
 
+    <TextView
+        android:id="@+id/representationInfo"
+        android:layout_width="352dp"
+        android:layout_height="23dp"
+        android:text=""
+        android:textColor="#FFFFFF"
+        app:layout_constraintStart_toStartOf="@+id/idExoPlayerVIew"
+        app:layout_constraintTop_toTopOf="@+id/idExoPlayerVIew" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/fivegmag_5GMSdAwareApplication/app/src/main/res/values/strings.xml
+++ b/fivegmag_5GMSdAwareApplication/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="labelM8Selection">Select M8 Input</string>
     <string name="labelStreamSelection">Select a Stream</string>
     <string name="startPlaybackButton">Start Playback</string>
+    <string name="representationInfo">%1$s kbit/s - Rep ID: %2$s</string>
 </resources>


### PR DESCRIPTION
Shows the current selected bitrate and the corresponding RepresentationID as an overlay on top of the video. 

To avoid polling the current bitrate every few seconds, we implemented a pub/sub pattern using an eventbus. Once the Representation is switched ,the MediaStreamHandler notifies all the subscribers about the change. In this case, the 5GMSd Aware Application uses the information (`mediaLoadData`) that is included in the notification event to update the UI.

As an example:
<img width="760" alt="Bildschirmfoto 2023-08-16 um 08 48 08" src="https://github.com/5G-MAG/rt-5gms-application/assets/2427039/527ed57e-ba8e-4d5e-8f67-649e044a1380">

